### PR TITLE
Added support for drawing triangles and image overlays

### DIFF
--- a/examples/Image/Image.ino
+++ b/examples/Image/Image.ino
@@ -49,8 +49,8 @@ void setup() {
     ft81x.beginDisplayList();
     ft81x.clear(FT81x_COLOR_RGB(0, 0, 0));
 
-    ft81x.drawBitmap(0, 120, 40, 240, 118, 1);
-    ft81x.drawBitmap(0, 0, 204, 240, 118, 2);
+    ft81x.drawBitmap(0, 120, 40, 240, 118, 1, 0);
+    ft81x.drawBitmap(0, 0, 204, 240, 118, 2, 0);
 
     ft81x.drawText(240, 460, 16, FT81x_COLOR_RGB(255, 0, 255), FT81x_OPT_CENTERX, "Image test\0");
 

--- a/src/FT81x.cpp
+++ b/src/FT81x.cpp
@@ -81,10 +81,10 @@
 #define MEDIAFIFO()                  0xFFFFFF39                                                                                                                             ///< Set up media FIFO in general purpose graphics RAM
 #define ROMFONT()                    0xFFFFFF3F                                                                                                                             ///< Load a ROM font into bitmap handle
 
-//KTOME addition
-#define BLEND_FUNC(src,dst)                ((0x0BL << 24) | (src << 3) | (dst))
-#define CMD_ROTATE()                       0xffffff29
-#define CMD_TRANSLATE()                    0xffffff27
+// KTOME addition
+#define BLEND_FUNC(src, dst) ((0x0BL << 24) | (src << 3) | (dst))
+#define CMD_ROTATE()         0xffffff29
+#define CMD_TRANSLATE()      0xffffff27
 
 #define BITMAPS      1  ///< Bitmap drawing primitive
 #define POINTS       2  ///< Point drawing primitive
@@ -263,29 +263,28 @@ void FT81x::drawRect(const int16_t x, const int16_t y, const uint16_t width, con
 }
 
 void FT81x::drawTri(const int16_t x1, const int16_t y1, const int16_t x2, const int16_t y2, const int16_t x3, const int16_t y3, const uint32_t color, const uint32_t bgcolor) {
-
     int16_t x_1;
     int16_t y_1;
-    int16_t x_2; // point 2 is highest (smallest y)
-    int16_t y_2; // point 2 is highest (smallest y)
+    int16_t x_2;  // point 2 is highest (smallest y)
+    int16_t y_2;  // point 2 is highest (smallest y)
     int16_t x_3;
     int16_t y_3;
 
-    if ((y1<=y2)&&(y1<=y3)){ // point 1 is highest on screen
+    if ((y1 <= y2) && (y1 <= y3)) {  // point 1 is highest on screen
         x_1 = x3;
         y_1 = y3;
         x_2 = x1;
         y_2 = y1;
         x_3 = x2;
         y_3 = y2;
-    } else if ((y2<=y3)&&(y2<=y1)){ // point 2 is highest
+    } else if ((y2 <= y3) && (y2 <= y1)) {  // point 2 is highest
         x_1 = x1;
         y_1 = y1;
         x_2 = x2;
         y_2 = y2;
         x_3 = x3;
         y_3 = y3;
-    } else { // point 3 highest
+    } else {  // point 3 highest
         x_1 = x2;
         y_1 = y2;
         x_2 = x3;
@@ -294,7 +293,7 @@ void FT81x::drawTri(const int16_t x1, const int16_t y1, const int16_t x2, const 
         y_3 = y1;
     }
 
-    if (x_2<=x_1){ // one colour wipe (2-3), two bg wipes
+    if (x_2 <= x_1) {  // one colour wipe (2-3), two bg wipes
         startCmd(COLOR(color));
         intermediateCmd(LINE_WIDTH(1 * 16));
         intermediateCmd(BEGIN(EDGE_STRIP_B));
@@ -306,7 +305,7 @@ void FT81x::drawTri(const int16_t x1, const int16_t y1, const int16_t x2, const 
         intermediateCmd(VERTEX2F(x_3 * 16, y_3 * 16));
         intermediateCmd(VERTEX2F(x_1 * 16, y_1 * 16));
         intermediateCmd(VERTEX2F(x_2 * 16, y_2 * 16));
-    } else if (x_2>=x_3){ // one colour wipe (1-2), two bg wipes
+    } else if (x_2 >= x_3) {  // one colour wipe (1-2), two bg wipes
         startCmd(COLOR(color));
         intermediateCmd(LINE_WIDTH(1 * 16));
         intermediateCmd(BEGIN(EDGE_STRIP_B));
@@ -318,7 +317,7 @@ void FT81x::drawTri(const int16_t x1, const int16_t y1, const int16_t x2, const 
         intermediateCmd(VERTEX2F(x_2 * 16, y_2 * 16));
         intermediateCmd(VERTEX2F(x_3 * 16, y_3 * 16));
         intermediateCmd(VERTEX2F(x_1 * 16, y_1 * 16));
-    } else { // two colour wipes, one bg wipe
+    } else {  // two colour wipes, one bg wipe
         startCmd(COLOR(color));
         intermediateCmd(LINE_WIDTH(1 * 16));
         intermediateCmd(BEGIN(EDGE_STRIP_B));
@@ -376,13 +375,13 @@ void FT81x::drawBitmap(const uint32_t offset, const uint16_t x, const uint16_t y
     intermediateCmd((uint32_t)scale * 65536);
     intermediateCmd((uint32_t)scale * 65536);
     intermediateCmd(CMD_TRANSLATE());
-    intermediateCmd((uint32_t)65536 * (width/2));
-    intermediateCmd((uint32_t)65536 * (height/2));
+    intermediateCmd((uint32_t)65536 * (width / 2));
+    intermediateCmd((uint32_t)65536 * (height / 2));
     intermediateCmd(CMD_ROTATE());
     intermediateCmd((uint32_t)rot * 65536 / 360);
     intermediateCmd(CMD_TRANSLATE());
-    intermediateCmd((uint32_t)65536 * -(width/2));
-    intermediateCmd((uint32_t)65536 * -(height/2));
+    intermediateCmd((uint32_t)65536 * -(width / 2));
+    intermediateCmd((uint32_t)65536 * -(height / 2));
     intermediateCmd(SETMATRIX());
 }
 
@@ -397,15 +396,15 @@ void FT81x::overlayBitmap(const uint32_t offset, const uint16_t x, const uint16_
     intermediateCmd((uint32_t)scale * 65536);
     intermediateCmd((uint32_t)scale * 65536);
     intermediateCmd(CMD_TRANSLATE());
-    intermediateCmd((uint32_t)65536 * (width/2));
-    intermediateCmd((uint32_t)65536 * (height/2));
+    intermediateCmd((uint32_t)65536 * (width / 2));
+    intermediateCmd((uint32_t)65536 * (height / 2));
     intermediateCmd(CMD_ROTATE());
     intermediateCmd((uint32_t)rot * 65536 / 360);
     intermediateCmd(CMD_TRANSLATE());
-    intermediateCmd((uint32_t)65536 * -(width/2));
-    intermediateCmd((uint32_t)65536 * -(height/2));
+    intermediateCmd((uint32_t)65536 * -(width / 2));
+    intermediateCmd((uint32_t)65536 * -(height / 2));
     intermediateCmd(SETMATRIX());
-    intermediateCmd(BLEND_FUNC(1,1));
+    intermediateCmd(BLEND_FUNC(1, 1));
     endCmd(VERTEX2II(x, y, 0, 0));
 }
 

--- a/src/FT81x.cpp
+++ b/src/FT81x.cpp
@@ -81,6 +81,11 @@
 #define MEDIAFIFO()                  0xFFFFFF39                                                                                                                             ///< Set up media FIFO in general purpose graphics RAM
 #define ROMFONT()                    0xFFFFFF3F                                                                                                                             ///< Load a ROM font into bitmap handle
 
+//KTOME addition
+#define BLEND_FUNC(src,dst)                ((0x0BL << 24) | (src << 3) | (dst))
+#define CMD_ROTATE()                       0xffffff29
+#define CMD_TRANSLATE()                    0xffffff27
+
 #define BITMAPS      1  ///< Bitmap drawing primitive
 #define POINTS       2  ///< Point drawing primitive
 #define LINES        3  ///< Line drawing primitive
@@ -257,6 +262,78 @@ void FT81x::drawRect(const int16_t x, const int16_t y, const uint16_t width, con
     endCmd(END());
 }
 
+void FT81x::drawTri(const int16_t x1, const int16_t y1, const int16_t x2, const int16_t y2, const int16_t x3, const int16_t y3, const uint32_t color, const uint32_t bgcolor) {
+
+    int16_t x_1;
+    int16_t y_1;
+    int16_t x_2; // point 2 is highest (smallest y)
+    int16_t y_2; // point 2 is highest (smallest y)
+    int16_t x_3;
+    int16_t y_3;
+
+    if ((y1<=y2)&&(y1<=y3)){ // point 1 is highest on screen
+        x_1 = x3;
+        y_1 = y3;
+        x_2 = x1;
+        y_2 = y1;
+        x_3 = x2;
+        y_3 = y2;
+    } else if ((y2<=y3)&&(y2<=y1)){ // point 2 is highest
+        x_1 = x1;
+        y_1 = y1;
+        x_2 = x2;
+        y_2 = y2;
+        x_3 = x3;
+        y_3 = y3;
+    } else { // point 3 highest
+        x_1 = x2;
+        y_1 = y2;
+        x_2 = x3;
+        y_2 = y3;
+        x_3 = x1;
+        y_3 = y1;
+    }
+
+    if (x_2<=x_1){ // one colour wipe (2-3), two bg wipes
+        startCmd(COLOR(color));
+        intermediateCmd(LINE_WIDTH(1 * 16));
+        intermediateCmd(BEGIN(EDGE_STRIP_B));
+        intermediateCmd(VERTEX2F(x_2 * 16, y_2 * 16));
+        intermediateCmd(VERTEX2F(x_3 * 16, y_3 * 16));
+        intermediateCmd(COLOR(bgcolor));
+        intermediateCmd(LINE_WIDTH(1 * 16));
+        intermediateCmd(BEGIN(EDGE_STRIP_B));
+        intermediateCmd(VERTEX2F(x_3 * 16, y_3 * 16));
+        intermediateCmd(VERTEX2F(x_1 * 16, y_1 * 16));
+        intermediateCmd(VERTEX2F(x_2 * 16, y_2 * 16));
+    } else if (x_2>=x_3){ // one colour wipe (1-2), two bg wipes
+        startCmd(COLOR(color));
+        intermediateCmd(LINE_WIDTH(1 * 16));
+        intermediateCmd(BEGIN(EDGE_STRIP_B));
+        intermediateCmd(VERTEX2F(x_1 * 16, y_1 * 16));
+        intermediateCmd(VERTEX2F(x_2 * 16, y_2 * 16));
+        intermediateCmd(COLOR(bgcolor));
+        intermediateCmd(LINE_WIDTH(1 * 16));
+        intermediateCmd(BEGIN(EDGE_STRIP_B));
+        intermediateCmd(VERTEX2F(x_2 * 16, y_2 * 16));
+        intermediateCmd(VERTEX2F(x_3 * 16, y_3 * 16));
+        intermediateCmd(VERTEX2F(x_1 * 16, y_1 * 16));
+    } else { // two colour wipes, one bg wipe
+        startCmd(COLOR(color));
+        intermediateCmd(LINE_WIDTH(1 * 16));
+        intermediateCmd(BEGIN(EDGE_STRIP_B));
+        intermediateCmd(VERTEX2F(x_1 * 16, y_1 * 16));
+        intermediateCmd(VERTEX2F(x_2 * 16, y_2 * 16));
+        intermediateCmd(VERTEX2F(x_3 * 16, y_3 * 16));
+        intermediateCmd(COLOR(bgcolor));
+        intermediateCmd(LINE_WIDTH(1 * 16));
+        intermediateCmd(BEGIN(EDGE_STRIP_B));
+        intermediateCmd(VERTEX2F(x_3 * 16, y_3 * 16));
+        intermediateCmd(VERTEX2F(x_1 * 16, y_1 * 16));
+    }
+    endCmd(END());
+}
+
 void FT81x::drawLine(const int16_t x1, const int16_t y1, const int16_t x2, const int16_t y2, const uint8_t width, const uint32_t color) {
     startCmd(COLOR(color));
     intermediateCmd(LINE_WIDTH(width * 16));
@@ -288,7 +365,7 @@ void FT81x::drawLetter(const int16_t x, const int16_t y, const uint8_t font, con
     endCmd(END());
 }
 
-void FT81x::drawBitmap(const uint32_t offset, const uint16_t x, const uint16_t y, const uint16_t width, const uint16_t height, const uint8_t scale) {
+void FT81x::drawBitmap(const uint32_t offset, const uint16_t x, const uint16_t y, const uint16_t width, const uint16_t height, const uint8_t scale, const uint8_t rot) {
     startCmd(COLOR(FT81x_COLOR_RGB(255, 255, 255)));
     intermediateCmd(BITMAP_SOURCE(FT81x_RAM_G + offset));
     intermediateCmd(BITMAP_LAYOUT(FT81x_BITMAP_LAYOUT_RGB565, (uint32_t)width * 2, (uint32_t)height));  // only supporting one format for now
@@ -298,7 +375,37 @@ void FT81x::drawBitmap(const uint32_t offset, const uint16_t x, const uint16_t y
     intermediateCmd(SCALE());
     intermediateCmd((uint32_t)scale * 65536);
     intermediateCmd((uint32_t)scale * 65536);
+    intermediateCmd(CMD_TRANSLATE());
+    intermediateCmd((uint32_t)65536 * (width/2));
+    intermediateCmd((uint32_t)65536 * (height/2));
+    intermediateCmd(CMD_ROTATE());
+    intermediateCmd((uint32_t)rot * 65536 / 360);
+    intermediateCmd(CMD_TRANSLATE());
+    intermediateCmd((uint32_t)65536 * -(width/2));
+    intermediateCmd((uint32_t)65536 * -(height/2));
     intermediateCmd(SETMATRIX());
+}
+
+void FT81x::overlayBitmap(const uint32_t offset, const uint16_t x, const uint16_t y, const uint16_t width, const uint16_t height, const uint8_t scale, const uint8_t rot) {
+    startCmd(COLOR(FT81x_COLOR_RGB(255, 255, 255)));
+    intermediateCmd(BITMAP_SOURCE(FT81x_RAM_G + offset));
+    intermediateCmd(BITMAP_LAYOUT(FT81x_BITMAP_LAYOUT_RGB565, (uint32_t)width * 2, (uint32_t)height));  // only supporting one format for now
+    intermediateCmd(BITMAP_SIZE(FT81x_BITMAP_SIZE_NEAREST, 0, 0, (uint32_t)width * (uint32_t)scale, (uint32_t)height * (uint32_t)scale));
+    intermediateCmd(BEGIN(BITMAPS));
+    intermediateCmd(LOADIDENTITY());
+    intermediateCmd(SCALE());
+    intermediateCmd((uint32_t)scale * 65536);
+    intermediateCmd((uint32_t)scale * 65536);
+    intermediateCmd(CMD_TRANSLATE());
+    intermediateCmd((uint32_t)65536 * (width/2));
+    intermediateCmd((uint32_t)65536 * (height/2));
+    intermediateCmd(CMD_ROTATE());
+    intermediateCmd((uint32_t)rot * 65536 / 360);
+    intermediateCmd(CMD_TRANSLATE());
+    intermediateCmd((uint32_t)65536 * -(width/2));
+    intermediateCmd((uint32_t)65536 * -(height/2));
+    intermediateCmd(SETMATRIX());
+    intermediateCmd(BLEND_FUNC(1,1));
     endCmd(VERTEX2II(x, y, 0, 0));
 }
 

--- a/src/FT81x.h
+++ b/src/FT81x.h
@@ -377,6 +377,20 @@ class FT81x {
     */
     void drawRect(const int16_t x, const int16_t y, const uint16_t width, const uint16_t height, const uint8_t cornerRadius, const uint32_t color);
 
+    // KTOME function for triangles
+    /*!
+        @brief  Draw triangle in current display list. Points must be defined in clockwise order. Only tested with equilateral tris.
+        @param  x1 x-coordinate for the first triangle point
+        @param  y1 y-coordinate for the first triangle point
+        @param  x2 x-coordinate for the first triangle point
+        @param  y2 y-coordinate for the first triangle point
+        @param  x3 x-coordinate for the first triangle point
+        @param  y3 y-coordinate for the first triangle point
+        @param  color Color of the rectangle
+        @param  bgcolor Color of the background
+    */
+    void drawTri(const int16_t x1, const int16_t y1, const int16_t x2, const int16_t y2, const int16_t x3, const int16_t y3, const uint32_t color,const uint32_t bgcolor);
+
     /*!
         @brief  Draw line in current display list
         @param  x1 x-coordinate for the start of the line
@@ -438,8 +452,21 @@ class FT81x {
         @param  width Width of the bitmap
         @param  height Height of the bitmap
         @param  scale Scale to resize the bitmap by
+        @param  rot Rotation of the image, in degrees, around the centre of the bitmap (works best with square images)
     */
-    void drawBitmap(const uint32_t offset, const uint16_t x, const uint16_t y, const uint16_t width, const uint16_t height, const uint8_t scale);
+    void drawBitmap(const uint32_t offset, const uint16_t x, const uint16_t y, const uint16_t width, const uint16_t height, const uint8_t scale, const uint8_t rot);
+
+    /*!
+        @brief  Overlay bitmap data (add pixel values to existing pixels)
+        @param  offset Offset in general purpose graphics RAM
+        @param  x x-coordinate for the top-left of the bitmap
+        @param  y y-coordinate for the top-left of the bitmap
+        @param  width Width of the bitmap
+        @param  height Height of the bitmap
+        @param  scale Scale to resize the bitmap by
+        @param  rot Rotation of the image, in degrees, around the centre of the bitmap (works best with square images)
+    */
+    void overlayBitmap(const uint32_t offset, const uint16_t x, const uint16_t y, const uint16_t width, const uint16_t height, const uint8_t scale, const uint8_t rot);
 
     /*!
         @brief  Draw a spinner in current display list

--- a/src/FT81x.h
+++ b/src/FT81x.h
@@ -389,7 +389,7 @@ class FT81x {
         @param  color Color of the rectangle
         @param  bgcolor Color of the background
     */
-    void drawTri(const int16_t x1, const int16_t y1, const int16_t x2, const int16_t y2, const int16_t x3, const int16_t y3, const uint32_t color,const uint32_t bgcolor);
+    void drawTri(const int16_t x1, const int16_t y1, const int16_t x2, const int16_t y2, const int16_t x3, const int16_t y3, const uint32_t color, const uint32_t bgcolor);
 
     /*!
         @brief  Draw line in current display list


### PR DESCRIPTION
Hi blazer82,

I don't use Github a heap so forgive me if this pull request is not correct... I added a few features to your library to give it more functionality for my purposes, and wondered if sharing would be useful.

Firstly, I've added drawing triangles. It uses the edge strip function, meaning that the area under the triangle will be cleared to the background colour, however if you draw items from top of the screen to the bottom, then it will draw correctly. It may be rather ineffecient code, but it works and can be improved if needed.

Second, I wanted to get images with alpha, however was unable to get formats other than RGB565 to work, so I created an "overlay" function that will add the pixel values of a bitmap to the screen. This will create a ghost-like image, however since I'm working with a mostly black screen and bitmaps with black backgrounds, this works as an effective alpha in my case.

Third, I've added support for image rotation. This works perfectly for square images that are rotated 90 degrees - other dimensions and angles will likely be clipped, but perhaps larger bitmaps with more margin may work well.

Example here: [https://imgur.com/mmS3ZAL](https://imgur.com/mmS3ZAL)